### PR TITLE
Release 1.0.4

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -100,6 +100,7 @@ class Validator:
             self.config.hotkey = self.wallet.hotkey.ss58_address
             self.config.run_name = self.run_name
             self.config.type = "validator"
+            self.config.version = pretrain.__version__
             self.wandb_run = wandb.init(
                 id = self.run_id,
                 name = self.run_name,
@@ -409,6 +410,7 @@ class Validator:
 
         # Create a new dictionary with the required format
         graphed_data = {
+            'time': time.time(),
             'block': self.subtensor.block,
             'uid_data': {str(uid): uid_data[str(uid)]['average_loss'] for uid in uids},
             'weight_data': {str(uid): self.weights[uid].item() for uid in uids}

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -263,8 +263,8 @@ class Validator:
             if 'timestamp' not in self.metadata[ j ]: return True 
             it = self.metadata[ i ]['timestamp']
             jt = self.metadata[ j ]['timestamp']
-            il = (1 - 0.03) * il if it < jt else il
-            jl = (1 - 0.03) * jl if jt < it else jl
+            il = (1 - 0.01) * il if it < jt else il
+            jl = (1 - 0.01) * jl if jt < it else jl
             if il < jl: return True
             else: return False
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -61,6 +61,7 @@ class Validator:
         parser.add_argument( '--pages_per_eval', type=int, default=3, help='Number of pages used to eval each step.' )
         parser.add_argument( '--sample_min', type=int, default=10, help='Number of uids to eval each step.' )
         parser.add_argument( '--reset_wandb', action='store_true', help='Creates a new wandb run instead of using an older on.' )
+        parser.add_argument( '--dont_set_weights', action='store_true', help='Creates a new wandb run instead of using an older on.' )
         bt.subtensor.add_args(parser)
         bt.logging.add_args(parser)
         bt.wallet.add_args(parser)
@@ -160,7 +161,7 @@ class Validator:
                 if pretrain.utils.update_model_for_uid( uid, self.metagraph ):
                     self.uids_to_eval.add( uid )
                     bt.logging.trace(f'uids to eval add: {uid}')
-                time.sleep( bt.__blocktime__ )
+                time.sleep( pretrain.update_model_timeout )
 
     def compute_losses_per_page( self, uid, batches_per_page: Dict[int, List[torch.Tensor]] ) -> Dict[int, List[float]]:
         try:
@@ -203,9 +204,49 @@ class Validator:
             losses_per_page[page] = page_losses
 
         return losses_per_page
-        
+
+    def try_sync_metagraph( self, ttl: int ):
+        @timeout( ttl )
+        def _try_sync_metagraph():
+            self.metagraph = self.subtensor.metagraph( pretrain.NETUID )
+        try: _try_sync_metagraph()
+        except TimeoutError: 
+            bt.logging.error(f'Failed to sync metagraph after {ttl} seconds')
+
+    def try_set_weights( self, ttl: int ):
+        @timeout( ttl )
+        def _try_set_weights():
+            try:
+                self.weights.nan_to_num( 0.0 )
+                self.subtensor.set_weights(
+                    netuid = pretrain.NETUID,
+                    wallet = self.wallet,
+                    uids = self.metagraph.uids,
+                    weights = self.weights,
+                    wait_for_inclusion=False,
+                )
+            except: pass
+            ws, ui = self.weights.topk( len( self.weights ) )
+            table = Table(title="All Weights")
+            table.add_column("uid", justify="right", style="cyan", no_wrap=True)
+            table.add_column("weight", style="magenta")
+            for index, weight in list(zip(ui.tolist(), ws.tolist())):
+                table.add_row(str(index), str(round(weight, 4)))
+            console = Console()
+            console.print(table)
+        try: _try_set_weights()
+        except TimeoutError: 
+            bt.logging.error(f'Failed to set weights after {ttl} seconds')
+
+    def try_run_step( self, ttl: int ):
+        @timeout( ttl )
+        def _try_run_step():
+            self.run_step()
+        try: _try_run_step()
+        except TimeoutError: 
+            bt.logging.error(f'Failed to run step after {ttl} seconds')
+
     # Add a 20 minute max timeout.
-    @timeout( RUN_STEP_MAX_TIME )
     def run_step( self ):
         # Load metadata.
         self.metadata = { uid: pretrain.utils.load_metadata_for_uid( uid ) for uid in self.metagraph.uids.tolist() }
@@ -263,8 +304,8 @@ class Validator:
             if 'timestamp' not in self.metadata[ j ]: return True 
             it = self.metadata[ i ]['timestamp']
             jt = self.metadata[ j ]['timestamp']
-            il = (1 - 0.01) * il if it < jt else il
-            jl = (1 - 0.01) * jl if jt < it else jl
+            il = (1 - pretrain.timestamp_epsilon) * il if it < jt else il
+            jl = (1 - pretrain.timestamp_epsilon) * jl if jt < it else jl
             if il < jl: return True
             else: return False
 
@@ -274,6 +315,7 @@ class Validator:
         for i in uids:
             total_matches = 0
             for j in uids:
+                if i == j: continue
                 for p in pages:
                     for b, _ in enumerate( batches_per_page[ p ] ):
                         wins[ i ] += 1 if better( i, j, p, b ) else 0
@@ -281,17 +323,15 @@ class Validator:
             win_rate[ i ] = wins[ i ] / total_matches
    
         # Compute and update weights which is a temperatured softmax over wins.
-        alpha = 0.9
-        temperature = 0.05
         step_weights = torch.tensor([ win_rate[ uid ] for uid in uids ], dtype=torch.float32)
-        softmax_step_weights = torch.softmax( step_weights / temperature, dim=0 )
+        softmax_step_weights = torch.softmax( step_weights / pretrain.temperature, dim=0 )
         new_weights = self.weights.clone()
         for i, uid in enumerate( uids ):
             new_weights[ uid ] = softmax_step_weights[ i ] 
         new_weights.nan_to_num( 0.0 )
         new_weights /= new_weights.sum()
         new_weights.nan_to_num( 0.0 )
-        self.weights = alpha * self.weights + ( 1 - alpha ) * new_weights
+        self.weights = pretrain.alpha * self.weights + ( 1 - pretrain.alpha ) * new_weights
 
         # Blacklist bad miners. Here we remove uids from eval set 
         # based on their win rate, this prunes miners down the sample min
@@ -376,37 +416,19 @@ class Validator:
         if self.config.wandb.on: 
             bt.logging.debug('Logging to Wandb')
             self.wandb_run.log({ **graphed_data, "original_format_json": original_format_json}, step=self.global_step)
+        bt.logging.debug('Finished run step.')
 
     def run(self):
         while True:
             try:            
                 while self.metagraph.block.item() - self.last_epoch < self.config.blocks_per_epoch:
-                    try: self.run_step()
-                    except TimeoutError: 
-                        bt.logging.error(f'Run step timedout after {RUN_STEP_MAX_TIME} seconds')
-                    self.metagraph = self.subtensor.metagraph( pretrain.NETUID )
+                    self.try_run_step( ttl = RUN_STEP_MAX_TIME )
+                    self.try_sync_metagraph( ttl = 60 )
                     bt.logging.debug(f"{self.metagraph.block.item() - self.last_epoch } / {self.config.blocks_per_epoch} blocks until next epoch.")
                     self.global_step += 1
 
-                # Finish epoch.
-                try:
-                    self.weights.nan_to_num( 0.0 )
-                    self.subtensor.set_weights(
-                        netuid = pretrain.NETUID,
-                        wallet = self.wallet,
-                        uids = self.metagraph.uids,
-                        weights = self.weights,
-                        wait_for_inclusion=False,
-                    )
-                except: pass
-                ws, ui = self.weights.topk( len( self.weights ) )
-                table = Table(title="All Weights")
-                table.add_column("uid", justify="right", style="cyan", no_wrap=True)
-                table.add_column("weight", style="magenta")
-                for index, weight in list(zip(ui.tolist(), ws.tolist())):
-                    table.add_row(str(index), str(round(weight, 4)))
-                console = Console()
-                console.print(table)
+                if not self.config.dont_set_weights:
+                    self.try_set_weights( ttl = 60 )
                 self.last_epoch = self.metagraph.block.item()
                 self.epoch_step += 1
 

--- a/pretrain/__init__.py
+++ b/pretrain/__init__.py
@@ -27,9 +27,19 @@ __spec_version__ = (
 NETUID = 9
 WANDB_PROJECT = 'pretraining-subnet'
 
+# validator weight moving average term
+alpha = 0.9
+# validator scoring exponential temperature
+temperature = 0.05
+# validator update model timeout (time between checking uids)
+update_model_timeout = 2 # 2 = checks all models every 256 * 2 seconds.
+# validator score boosting for earlier models.
 timestamp_epsilon = 0.01
+# validators number of pages to eval over miners on each step.
 n_eval_pages = 3
-batch_size = 3
+# validator eval batch size.
+batch_size = 1
+# validator eval sequence length.
 sequence_length = 1024
 
 import os

--- a/pretrain/__init__.py
+++ b/pretrain/__init__.py
@@ -17,7 +17,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/pretrain/__init__.py
+++ b/pretrain/__init__.py
@@ -27,11 +27,10 @@ __spec_version__ = (
 NETUID = 9
 WANDB_PROJECT = 'pretraining-subnet'
 
-best_uid_epsilon = 0.03
-per_loss_epsilon = 0.05
+timestamp_epsilon = 0.01
 n_eval_pages = 3
 batch_size = 3
-sequence_length = 512
+sequence_length = 1024
 
 import os
 netuid_dir = os.path.expanduser(f'~/.bittensor/miners/netuid{NETUID}/')

--- a/pretrain/model.py
+++ b/pretrain/model.py
@@ -23,9 +23,9 @@ config = GPT2Config()
 
 def get_model():
     config = GPT2Config(
-        n_head = 12,
+        n_head = 10,
         n_layer = 12,
-        n_embd = 480,
+        n_embd = 760,
     )
     return GPT2LMHeadModel(config)
 

--- a/pretrain/utils.py
+++ b/pretrain/utils.py
@@ -75,6 +75,14 @@ def update_model_for_uid( uid:int, metagraph: typing.Optional[ bt.metagraph ] = 
     metadata_file = os.path.join( models_dir, 'metadata.json' )
     model_path = os.path.join( models_dir, 'model.pth' )
 
+    # Delete models where there is no file.
+    if len( runs ) == 0:
+        if os.path.exists(metadata_file):
+            os.remove(metadata_file)
+        if os.path.exists(model_path):
+            os.remove(model_path)
+        return False
+
     # Iterate through runs. Newer runs first.
     for run in runs:
         bt.logging.trace(f'check run: {run.id}')
@@ -85,7 +93,11 @@ def update_model_for_uid( uid:int, metagraph: typing.Optional[ bt.metagraph ] = 
             bt.logging.trace(f'Run:{run.id}, for uid:{uid} was valid.')
             
             # Run artifact.
-            model_artifact = run.file('model.pth')
+            try:
+                model_artifact = run.file('model.pth')
+            except:
+                # No model, continue.
+                continue
 
             # Define the local model directory and timestamp file paths
             timestamp = int(datetime.strptime(model_artifact.updatedAt, '%Y-%m-%dT%H:%M:%S').timestamp())

--- a/pretrain/utils.py
+++ b/pretrain/utils.py
@@ -81,6 +81,7 @@ def update_model_for_uid( uid:int, metagraph: typing.Optional[ bt.metagraph ] = 
             os.remove(metadata_file)
         if os.path.exists(model_path):
             os.remove(model_path)
+        bt.logging.error(f'Deleting {uid} model with no run.')
         return False
 
     # Iterate through runs. Newer runs first.
@@ -129,6 +130,13 @@ def update_model_for_uid( uid:int, metagraph: typing.Optional[ bt.metagraph ] = 
             # The run failed the signature check. Moving to the next run.
             bt.logging.trace(f'Run:{run.id}, for uid:{uid} was not valid with error: {reason}')
             continue
+
+    # Deleting model path if no valid runs.
+    if os.path.exists(metadata_file):
+        os.remove(metadata_file)
+    if os.path.exists(model_path):
+        os.remove(model_path)
+    bt.logging.error(f'Deleting {uid} model with no valid run.')
     return False
 
 def load_metadata_for_uid( uid: int ):


### PR DESCRIPTION
The release has the following breaking changes.

-- Increases version number from 1.0.3 --> 1.0.4. This forces an update on all miners and validators.
-- Increase model size from 54M params to 122M params (slightly smaller than GPT2 small)
-- Reduces timestamp advantage from 3% to 1%.
-- Increases sequence length from 512 --> 1024