### PR TITLE
Add auto-update script for the validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,32 +181,48 @@ Loading the best model on the network based on its incentive.
 python neurons/miner.py --wallet.name ... --wallet.hotkey ... --num_epochs 10 --pages_per_epoch 5 --load_best
 ```
 
-Pass the `--device` option to select which GPU to run on. 
+Pass the `--device` option to select which GPU to run on.
 
 ---
 
 ## Validating
 
-The validation script pulls runs from the wandb project and evaluates them continuously on Falcon. 
-Note: validation requires you have a working GPU which you pass via `--device`. In this version release/2.0.1 you need a GPU with atleast 20GB of RAM. 
+The validation script pulls runs from the wandb project and evaluates them continuously on Falcon.
+Note: validation requires you have a working GPU which you pass via `--device`. In this version release/2.0.1 you need a GPU with atleast 20GB of RAM.
 
 Test running validation:
 ```bash
-python neurons/validator.py 
+python neurons/validator.py
     --wallet.name YOUR_WALLET_NAME
-    --wallet.hotkey YOUR_WALLET_HOTKEY 
+    --wallet.hotkey YOUR_WALLET_HOTKEY
     --device YOUR_CUDA DEVICE
     --wandb.off
     --offline
 ```
 
-Running your validator: 
+Running your validator:
 ```bash
-python neurons/validator.py 
+python neurons/validator.py
     --wallet.name YOUR_WALLET_NAME
-    --wallet.hotkey YOUR_WALLET_HOTKEY 
+    --wallet.hotkey YOUR_WALLET_HOTKEY
     --device YOUR_CUDA DEVICE
 ```
+
+### Auto-updates
+
+It is essential to keep your validator up to date. There is a helper script which will automatically update your validator to the latest version. In order to use it, the repo
+should be initialized and have proper reference to `origin` remote - i.e. if you cloned the repo, you're all set.
+
+To run the auto-updater script, use the following command:
+```bash
+scripts/start_validator.sh
+    --wallet.name YOUR_WALLET_NAME
+    --wallet.hotkey YOUR_WALLET_HOTKEY
+    --device YOUR_CUDA_DEVICE
+```
+
+For more information about the script, refer to [script docstrings](scripts/start_validator.py).
+
 ---
 
 ## Bittensor API

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-bittensor
-torch
+bittensor==6.5.0
+torch==2.1.2
 transformers==4.34.1
-wandb
-rich
-matplotlib
-safetensors
+wandb==0.16.1
+rich==13.7.0
+matplotlib==3.8.2
+safetensors==0.4.1
+envparse==0.2.0

--- a/scripts/start_validator.py
+++ b/scripts/start_validator.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+This script runs a validator process and automatically updates it when a new version is released.
+
+Command-line arguments will be forwarded to validator (`neurons/validator.py`), so you can pass
+them like this:
+
+    python3 scripts/start_validator.py --wallet.name=my-wallet
+
+Auto-updates are enabled by default and will make sure that the latest version is always running
+by pulling the latest version from git and upgrading python packages. This is done periodically.
+Local changes may prevent the update, but they will be preserved.
+
+To disable auto-updates, set `AUTO_UPDATE` environment variable to `0`:
+
+    AUTO_UPDATE=0 python3 scripts/start_validator.py
+
+The script will use the same virtual environment as the one used to run it. If you want to run
+validator within virtual environment, run this auto-update script from the virtual environment.
+"""
+import logging
+import os
+import subprocess
+import sys
+import time
+from datetime import timedelta
+from pathlib import Path
+from shlex import split
+
+from envparse import env
+
+log = logging.getLogger(__name__)
+UPDATES_CHECK_TIME = timedelta(minutes=5)
+ROOT_DIR = Path(__file__).parent.parent
+
+
+def get_version() -> str:
+    """ Extract the version as current git commit hash """
+    result = subprocess.run(
+        split("git rev-parse HEAD"),
+        check=True, capture_output=True, cwd=ROOT_DIR,
+    )
+    commit = result.stdout.decode().strip()
+    assert len(commit) == 40, f'Invalid commit hash: {commit}'  # noqa: PLR2004
+    return commit[:8]
+
+def start_validator_process() -> subprocess.Popen:
+    """
+    Spawn a new python process running neurons.validator.
+
+    `sys.executable` ensures thet the same python interpreter is used as the one
+    used to run this auto-updater.
+    """
+    assert sys.executable, 'Failed to get python executable'
+    validator = subprocess.Popen(
+        (*split(f"{sys.executable} -m neurons.validator"), *sys.argv),
+        cwd=ROOT_DIR,
+        preexec_fn=os.setsid,
+    )
+    time.sleep(1)
+    if (return_code := validator.poll()) is not None:
+        raise RuntimeError('Failed to start validator process, return code: %s', return_code)
+    return validator
+
+
+def pull_latest_version() -> None:
+    """
+    Pull the latest version from git.
+
+    This uses `git pull --rebase`, so if any changes were made to the local repository,
+    this will try to apply them on top of origin's changes. This is intentional, as we
+    don't want to overwrite any local changes. However, if there are any conflicts,
+    this will abort the rebase and return to the original state.
+
+    The conflicts are expected to happen rarely since validator is expected
+    to be used as-is.
+    """
+    try:
+        subprocess.run(split("git pull --rebase --autostash"), check=True, cwd=ROOT_DIR)
+    except subprocess.CalledProcessError as exc:
+        log.error('Failed to pull, reverting: %s', exc)
+        subprocess.run(split("git rebase --abort"), check=True, cwd=ROOT_DIR)
+
+
+def upgrade_packages() -> None:
+    """
+    Upgrade python packages by running `pip install --upgrade -r requirements.txt`.
+
+    Notice: this won't work if some package in `requirements.txt` is downgraded.
+    Ignored as this is unlikely to happen.
+    """
+
+    log.info('Upgrading packages')
+    try:
+        subprocess.run(
+            split("pip install --upgrade --disable-pip-version-check -r requirements.txt"),
+            check=True, cwd=ROOT_DIR,
+        )
+    except subprocess.CalledProcessError as exc:
+        log.error('Failed to upgrade packages, proceeding anyway. %s', exc)
+
+
+def main(auto_update: bool = True) -> None:
+    """
+    Run the validator process and automatically update it when a new version is released.
+
+    This will check for updates every `UPDATES_CHECK_TIME` and update the validator
+    if a new version is available. Update is performed as simple `git pull --rebase`.
+    """
+
+    validator = start_validator_process()
+    current_version = latest_version = get_version()
+    log.info('Current version: %s', current_version)
+
+    try:
+        while True:
+            if auto_update:
+                pull_latest_version()
+                latest_version = get_version()
+                log.info('Latest version: %s', latest_version)
+
+            if latest_version != current_version:
+                log.info('Upgraded to latest version: %s -> %s', current_version, latest_version)
+                upgrade_packages()
+
+                validator.terminate()
+                validator = start_validator_process()
+                current_version = latest_version
+
+            time.sleep(UPDATES_CHECK_TIME.total_seconds())
+
+    finally:
+        if validator.poll() is None:
+            validator.terminate()
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+    main(
+        auto_update=env.bool('AUTO_UPDATE', default=True),
+    )


### PR DESCRIPTION
This PR adds an auto-update script for the validator.

It is just a python script (no external program needed) which invokes the validator process and tracks changes in git origin. When new commit appears, local repository pulls it and restarts validator.

This will always update validators to latest version from git, so if features are developed in separate branches, they won't affect validators currently running on `main`; however, pushing commits to `main` will immediately affect validators.

The script will respect activated virtual environment, so it does not pollute global python env unless user wants to.

As discussed earlier, this is not really a solid solution but instead a quick solution to a problem. The goal is to provide a tool to quickly run & update validators without need to mess with setup. At later stages it is recommended to switch to `docker-compose` for environment consistency across miners, resource limitations, auto-restarts, logging, more controlled upgrades etc.